### PR TITLE
Feature #19: SSH-keys copied over automagically

### DIFF
--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -141,7 +141,7 @@ def generate_printable_string(num_chars):
     return result
 
 
-def generate_ssh_keypair(pem_only=False):
+def generate_ssh_keypair(in_template=True):
     """
     Generates a 4096 bit ssh-keypair
     :return: Tuple (str, str)
@@ -149,7 +149,6 @@ def generate_ssh_keypair(pem_only=False):
     key = RSA.generate(4096)
     public = key.publickey().exportKey('OpenSSH')
     private = key.exportKey('PEM')
-    if pem_only:
-        public = None
-    private = re.sub(r"\n", "\n  ", private)
+    if in_template:
+        private = re.sub(r"\n", "\n  ", private)
     return public, private


### PR DESCRIPTION
- Confirms user to add ssh public key to on server
- Interactive menu for project environments
- Make backing up `fabric_settings.py` an option (for people like me)

@rmutter, still to be done is programmatically tweaking `/etc/ssh/sshd_config` (will put in another issue) to disable password authentication and enable key authentication. It might be messy. 