### PR TITLE
Honey Bunches of Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ deploying using Ansible to either a Vagrant or web host instance.
 2. Symlink the fabfile from the yurt directory to the project directory
 
     ```
-    sudo ln -s ~/projects/yurt/fabfile .
+    ln -s ~/projects/yurt/fabfile .
     ```
 
 #### NEW project Setup
@@ -96,6 +96,49 @@ deploying using Ansible to either a Vagrant or web host instance.
    ```
 2. Enter the SSH link to your repo
 
+## Creating a new remote deployment target
+
+1. Navigate to the project directory
+
+    ```
+    cd ~/projects/new_proj
+    ```
+    
+2. Enter the following command
+
+    ```
+    fab add.remote_server
+    ```
+
+3. Answer the interactive questions
+
+4. Confirm the settings by pressing Enter!
+
+5. You now have a target server that can be deployed to. Let's prep that server!
+
+## Prepping the Server (with PEM credentials)
+
+1. Navigate to the project directory
+
+    ```
+    cd ~/projects/new_proj
+    ```
+
+2. Creating the PEM file: Enter the following command
+
+    ```
+    fab setup.create_pem_file
+    ```
+
+3. Copying the PEM file to the Remote Server: Enter the following command
+
+    ```
+    fab setup.copy_pem_file
+    ```
+    * Stick with the default 'root' user
+
+4. You're ready to deploy
+
 ## Deploying a Yurt Project
 
 1. Navigate to the repo in the project directory
@@ -103,14 +146,16 @@ deploying using Ansible to either a Vagrant or web host instance.
    ```
    cd ~/projects/new_proj/<repo_name>
    ```
+
+2. Make sure your target branch has been committed and pushed to remote.
    
-2. Enter the following command
+3. Enter the following command
 
    ```
    ansible-playbook -i orchestration/inventory/<environment> orchestration/site.yml
    ```
    
-   * where `<environment>` is either `development`, `staging` or `production`
+   * where `<environment>` is the environment name you set in `Creating a new remote deployment target` (i.e. "development", "staging", or "production")
 
 ## Testing
 

--- a/fabfile/add.py
+++ b/fabfile/add.py
@@ -5,27 +5,25 @@ from collections import OrderedDict
 from fabric.decorators import task
 from fabric.operations import local
 from fabric.context_managers import lcd
-from context_managers import bash
 
-from utils import add_fab_path_to_bashrc, get_project_name_from_repo, \
-    generate_printable_string, recursive_file_modify, raw_input_wrapper
+from utils import get_project_name_from_repo, generate_printable_string, recursive_file_modify, raw_input_wrapper
 
 ATTRIBUTE_TO_QUESTION_MAPPING = OrderedDict([
     ("git_repo", "Enter the git repository link\n(i.e. git@github.com:mr_programmer/robot_repository.git):\t"),
-    ("env", "What name is this environment (ie development, staging, production)?:\t "),
-    ("abbrev_env", "How do you want this environment abbreviated (i.e. dev, stage, prod)?:\t "),
-    ("app_host_ip", "What is the public IP address of this project's host (i.e. 123.45.67.89)?:\t"),
-    ("db_host_ip", "What is the IP address of this project's DB host (Hint: `app_host_ip` if hosted locally)?:\t"),
-    ("debug", "This Django server will use Debug mode (True/False):\t"),
+    ("env", "What name is this environment (i.e. development, staging, production)?: "),
+    ("abbrev_env", "How do you want this environment abbreviated (i.e. dev, stage, prod)?: "),
+    ("app_host_ip", "What is the public DNS of this project's host (i.e. example.com)?: "),
+    ("db_host_ip", "What is this project's DB host (Hint: public IP of project if hosted locally)?: "),
+    ("debug", "This Django server will use Debug mode (True/False): "),
     ("num_gunicorn_workers", "".join(("How many gunicorn workers do you want ",
                                       "(Hint: For the number of workers, a go",
-                                      "od rule to follow is 2 x number of CPUs + 1)?:\t"))),
+                                      "od rule to follow is 2 x number of CPUs + 1)?: "))),
     ("gunicorn_max_requests", "".join(("What do you want to set `gunicorn_max_requests` to ? ",
                                        "Setting this to 1 will restart the Gunicorn process each time ",
                                        "you make a request, basically reloading the code. Very han",
-                                       "dy when developing. Set to 0 for unlimited requests.:\t"))),
-    ("ssl_enabled", "Is SSL enabled on this server (yes/no)?:\t"),
-    ("git_branch", "From which git branch will the server pull the project?:\t")
+                                       "dy when developing. Set to 0 for unlimited requests.: "))),
+    ("ssl_enabled", "Is SSL enabled on this server (yes/no)?: "),
+    ("git_branch", "From which git branch will the server pull the project?: ")
 ])
 
 TEMPLATE_TO_PROJECT_MAPPING = {
@@ -40,7 +38,6 @@ def remote_server():
     if os.path.exists("./templates.tmp"):
         print "A `templates.tmp` directory is in the current working directory. Delete this before trying again."
         return None
-    add_fab_path_to_bashrc()
     lowercase_attrs = ["env", "abbrev_env"]
     settings = {
         "secret_key": generate_printable_string(40),
@@ -48,7 +45,7 @@ def remote_server():
     }
     raw_input("You will be asked a bunch of questions for setting up the server.\nMake sure your "
               "input is as accurate as possible.\nIf given a choice in parentheses, make sure\n"
-              "the choice you enter matches one of those choices.\n"
+              "the input you enter matches one of those choices.\n"
               "Press Enter to Continue.")
 
     for attribute, prompt in ATTRIBUTE_TO_QUESTION_MAPPING.iteritems():
@@ -66,9 +63,8 @@ def remote_server():
         print "{0} : {1}, ".format(attr, value)
     print "}\n"
     raw_input("Press Enter to Continue or Ctrl+C to Cancel")
-    with bash():
-        local("cp -rf $FAB_PATH/../templates ./templates.tmp")
-        recursive_file_modify("./templates.tmp", settings)
+    local("cp -rf ./fabfile/../templates ./templates.tmp")
+    recursive_file_modify("./templates.tmp", settings)
     with lcd("./templates.tmp"):
         for filepath, dest_template in TEMPLATE_TO_PROJECT_MAPPING.iteritems():
             destination = dest_template.format(settings.get("project_name"),

--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -25,11 +25,8 @@ def create_project():
     env.settings = get_fab_settings()
     env.proj_name = get_project_name_from_repo(env.settings.get('git_repo'))
     env.settings['project_name'] = env.proj_name
-
-    with bash():
-        with lcd(env.proj_name):
-            local("cp -rf $FAB_PATH/../django_project/* .")
-        recursive_file_modify(os.path.abspath("./{0}".format(env.proj_name)), env.settings)
+    local("cp -rf ./fabfile/../django_project/ ./{0}".format(env.proj_name))
+    recursive_file_modify(os.path.abspath("./{0}".format(env.proj_name)), env.settings)
 
 
 @task
@@ -44,10 +41,9 @@ def load_orchestration_and_requirements():
     env.settings['project_name'] = env.proj_name
     env.settings['repo_name'] = env.proj_name
 
-    with bash():
-        local('cp -rf $FAB_PATH/../orchestration ./{0}'.format(env.proj_name))
-        local('cp -f $FAB_PATH/requirements.txt ./{0}'.format(env.proj_name))
-        recursive_file_modify('./{0}/orchestration'.format(env.proj_name), env.settings)
+    local('cp -rf ./fabfile/../orchestration ./{0}'.format(env.proj_name))
+    local('cp -f ./fabfile/requirements.txt ./{0}'.format(env.proj_name))
+    recursive_file_modify('./{0}/orchestration'.format(env.proj_name), env.settings)
 
 
 @task
@@ -86,13 +82,10 @@ def create_pem_file():
     Generates an SSH Key Pair (that is added to your keychain and `~/.ssh` directory)
     :return:
     """
-    try:
-        env.settings = get_fab_settings()
-        pub, pem = generate_ssh_keypair(in_template=False)
-        project_name = get_project_name_from_repo(env.settings.get('git_repo'))
-    except:
-        project_name = raw_input("What will you name this ssh_key? (Hint: just an alphanumeric name that\
-        describes what the key is for)")
+    pub, pem = generate_ssh_keypair(in_template=False)
+
+    project_name = raw_input("What will you name this ssh_key?\
+    (Hint: just an alphanumeric name that describes what the key is for):\t")
 
     with open("./{0}.pem".format(project_name), 'w') as key:
         key.write(pem)
@@ -102,23 +95,19 @@ def create_pem_file():
         key.write(pub)
         local("mv ./{0}.pub ~/.ssh".format(project_name))
         local("ssh-add ~/.ssh/{0}.pem".format(project_name))
-    print("PEM-file `~/.ssh/{0}.pem` added!")
+    print("PEM-file `~/.ssh/{0}.pem` added!".format(project_name))
 
 
 @task
-def copy_pem_file(user=None, host=None, key_name=None, environment=None):
+def copy_pem_file(user=None, host=None, key_name=None):
     """
     Appends public SSH Key (named after `project_name` in `fabric_settings.py`) to remote host
     :param user: str, Remote user
     :param host: str, Remote ip address
-    :param environment: Dict, Environment Dictionary
+    :param key_name: str, Name of Key_pair in ~/.ssh
     :return:
     """
-    try:
-        env.settings = get_fab_settings()
-        project_name = get_project_name_from_repo(env.settings.get('git_repo'))
-    except:
-        project_name = key_name
+    project_name = key_name
     env.user = user
     env.host_string = host
 
@@ -129,11 +118,34 @@ def copy_pem_file(user=None, host=None, key_name=None, environment=None):
         else:
             env.user = user
     if host is None:
-        env.host_string = environment.get('app_host_ip')
+        env.host_string = raw_input("Public IP/DNS of Remote Server?:\t")
+    if key_name is None:
+        KEYNAME_ENUM = {}
+        key_names = set([filename.split('.')[0]
+                         if "." in filename
+                         else filename
+                         for filename in os.listdir(os.path.expanduser("~/.ssh"))])
+        key_names.remove("config")
+        print "Option\tKeyname"
+        print "______\t_______"
+        for index, keyname in enumerate(key_names):
+            KEYNAME_ENUM[str(index)] = keyname
+            print "{0}:\t{1}".format(index, keyname)
+        print ""
+        try:
+            project_name = KEYNAME_ENUM[raw_input("".join(("Which key in ~/.ssh are you ",
+                                                           "copying to the remote server (Input the option)?:\t")))]
+        except KeyError:
+            print KeyError("Not a good input!")
+            return
+    print "If prompted for 'Passphrase for private key:', ssh input the password credentials for this server."
     run('mkdir -p ~/.ssh')
     with open(os.path.expanduser('~/.ssh/{0}.pub'.format(project_name)), 'r') as key:
         append("~/.ssh/authorized_keys", key.readline().rstrip("\n"))
-    print("Pub key added to `/home/{0}/.ssh/authorized_keys` in server".format(env.user))
+    if env.user == "root":
+        print("Pub key added to `/{0}/.ssh/authorized_keys` in server".format(env.user))
+    else:
+        print("Pub key added to `/home/{0}/.ssh/authorized_keys` in server".format(env.user))
 
 
 @task
@@ -166,7 +178,6 @@ def new(PEM_copy=None):
     env.proj_name = get_project_name_from_repo(env.settings.get('git_repo'))
     env.settings['project_name'] = env.proj_name
     env.git_repo_url = env.settings.get('git_repo')
-    add_fab_path_to_bashrc()
     execute(enable_git_repo)
     execute(create_project)
     execute(load_orchestration_and_requirements)
@@ -197,7 +208,6 @@ def existing():
     Sets up existing project local environment
     :return:
     """
-    add_fab_path_to_bashrc()
     git_repo = raw_input("Enter the git repository link\n(i.e. git@github.com:mr_programmer/robot_repository.git):\t")
     project_name = get_project_name_from_repo(git_repo)
     repo_name = get_project_name_from_repo(git_repo, False)
@@ -207,8 +217,7 @@ def existing():
     }
     local("git clone {0}".format(git_repo))
     local("mv ./{0} ./{1}".format(repo_name, project_name))
-    with bash():
-        local("cp $FAB_PATH/../orchestration/Vagrantfile ./")
+    local("cp ./fabfile/../orchestration/Vagrantfile ./")
     recursive_file_modify('./Vagrantfile', env.settings, is_dir=False)
     local("vagrant up")
 
@@ -219,7 +228,6 @@ def add_settings():
     Adds `fabric_settings.py` to this directory
     :return: Void
     """
-    add_fab_path_to_bashrc()
     public_key, private_key = generate_ssh_keypair()
     SETTINGS = {
         'git_public_key': public_key,
@@ -236,8 +244,7 @@ def add_settings():
         else:
             print("Aborted.")
             return False
-    with bash():
-        local('cp $FAB_PATH/fabric_settings.py.default.py ./fabric_settings.py')
-        recursive_file_modify('./fabric_settings.py', SETTINGS, is_dir=False)
-        print("".join(("You now have `fabric_settings.py`. Edit this file to have the correct ",
-                       "values and then enter `fab setup.new`")))
+    local('cp ./fabfile/fabric_settings.py.default.py ./fabric_settings.py')
+    recursive_file_modify('./fabric_settings.py', SETTINGS, is_dir=False)
+    print("".join(("You now have `fabric_settings.py`. Edit this file to have the correct ",
+                   "values and then enter `fab setup.new`")))

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -22,7 +22,7 @@ def get_fab_settings():
             sys.path.append(".")
             return __import__("fabric_settings", globals(), locals(), [], 0).FABRIC
         except ImportError:
-            raise Exception('Create `fabric_settings.py` file in this directory')
+            raise ImportError('Create `fabric_settings.py` file in this directory')
 
 
 def get_file_text(path):
@@ -60,7 +60,6 @@ def _perform_substitution(filepath, dictionary, pattern, all_vars_pattern):
         file_text = re.sub(var_pattern, target_dictionary.get(variable), file_text)
     with open(filepath, 'w') as change_file:
         change_file.write(file_text)
-
 
 
 def recursive_file_modify(path, dictionary, pattern=r"%\(({0})\)s", is_dir=True):

--- a/orchestration/env_vars/vagrant.yml
+++ b/orchestration/env_vars/vagrant.yml
@@ -26,3 +26,5 @@ django_secret_key: "%(vagrant.secret_key)s"
 
 run_django_db_migrations: yes
 run_django_collectstatic: yes
+
+bashrc_path: "/home/vagrant/.bashrc"

--- a/orchestration/roles/app/tasks/create_users_and_groups.yml
+++ b/orchestration/roles/app/tasks/create_users_and_groups.yml
@@ -8,3 +8,6 @@
 
 - name: Add the application user to the application group
   user: name={{ gunicorn_user }} group={{ gunicorn_group }} state=present
+
+- name: Create /server/ directory
+  file: path=/server state=directory mode=0755

--- a/orchestration/roles/app/tasks/setup_virtualenv.yml
+++ b/orchestration/roles/app/tasks/setup_virtualenv.yml
@@ -4,16 +4,13 @@
   pip: name=virtualenvwrapper executable="/usr/bin/pip3"
 
 - name: Export WORKON_HOME in .bashrc
-  lineinfile: dest=/home/{{ gunicorn_user }}/.bashrc line="export WORKON_HOME=$HOME/.virtualenvs"
-
-- name: Export PROJECT_HOME in .bashrc
-  lineinfile: dest=/home/{{ gunicorn_user }}/.bashrc line="export PROJECT_HOME=$HOME/Devel"
+  lineinfile: dest={{ bashrc_path }} line="export WORKON_HOME=/server/.virtualenvs"
 
 - name: Export VIRTUALENVWRAPPER_PYTHON in .bashrc
-  lineinfile: dest=/home/{{ gunicorn_user }}/.bashrc line="export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3"
+  lineinfile: dest={{ bashrc_path }} line="export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3"
 
 - name: Source virtualenvwrapper.sh in .bashrc
-  lineinfile: dest=/home/{{ gunicorn_user }}/.bashrc line="source /usr/local/bin/virtualenvwrapper.sh"
+  lineinfile: dest={{ bashrc_path }} line="source /usr/local/bin/virtualenvwrapper.sh"
 
 - name: Create the virtualenv
   command: virtualenv -p python3 {{ virtualenv_path }}
@@ -29,10 +26,10 @@
   tags: deploy
 
 - name: Copy 'workon {environment}' statement to .bashrc
-  lineinfile: dest=/home/{{ gunicorn_user }}/.bashrc line="workon {{ application_name }}"
+  lineinfile: dest={{ bashrc_path }} line="workon {{ application_name }}"
 
 - name: Copy 'cd /path/to/application' statement to .bashrc
-  lineinfile: dest=/home/{{ gunicorn_user }}/.bashrc line="cd {{ project_path }}"
+  lineinfile: dest={{ bashrc_path }} line="cd {{ project_path }}"
 
 - name: Set permission to virtualenv path
   file: path={{ virtualenv_path }}
@@ -41,20 +38,20 @@
         group={{ gunicorn_group }}
         state=directory
 
-- name: Create /server/ directory
-  file: path=/server
-        owner={{ gunicorn_user }}
-        group={{ gunicorn_group }}
-        state=directory
-  when: env == "vagrant"
-
 - name: Create symlink for repository for development
   file: src=/vagrant/{{application_name}} dest={{ project_path }} state=link
   when: env == "vagrant"
 
+- name: Create directory for repository
+  file: path={{ project_path }}
+        state=directory
+        owner={{ gunicorn_user }}
+        group={{ gunicorn_user }}
+  when: env != "vagrant"
+
 - name: Create the maintenance page
   template: src=maintenance_off.html
-            dest={{ project_path }}/maintenance_off.html
+            dest=/server/maintenance_off.html
             mode=0664
 
 

--- a/orchestration/roles/app/templates/nginx_site_config.j2
+++ b/orchestration/roles/app/templates/nginx_site_config.j2
@@ -16,6 +16,7 @@ server {
 
 server {
     listen              {% if ssl_enabled %}443;{% else %}80;{% endif %}
+
     server_name         {{ nginx_server_name }};
 
     {% if ssl_enabled %}

--- a/orchestration/roles/app/vars/main.yml
+++ b/orchestration/roles/app/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Application settings.
-virtualenv_path: "/home/{{ gunicorn_user }}/.virtualenvs/{{ application_name }}"
+virtualenv_path: "/server/.virtualenvs/{{ application_name }}"
 virtualenv_python: "{{ virtualenv_path }}/bin/python"
 project_path: "/server/{{ application_name }}"
 application_log_dir: "{{ virtualenv_path }}/logs"

--- a/templates/env_vars.yml.template
+++ b/templates/env_vars.yml.template
@@ -1,6 +1,6 @@
 ---
 env: "%(env)s"
-project_path: "/home/{{ application_name }}"
+project_path: "/server/{{ application_name }}"
 
 # Git settings.
 setup_git_repo: yes
@@ -40,3 +40,5 @@ django_secret_key: "%(secret_key)s"
 
 run_django_db_migrations: yes
 run_django_collectstatic: yes
+
+bashrc_path: "/root/.bashrc"


### PR DESCRIPTION
- [YURT-36] FAB_PATH breaking
  - just use symlinked `fabfile` path
  - remove all `bash()` context manager invocations
- [YURT-38] Auto-generated Server Project Path Incorrect
  - set project path to `/server/{{ application_name }}`
  - also, set `WORKON_HOME` to `/server/.virtualenvs`
- [YURT-35] Change README to say `ln -s ...` instead of `sudo ln -s`
- [YURT-39] Add new flows to README, more information about when commits should be pushed, disclaimer about how user needs to be able to login to server as root

@rmutter, @baylee: It's more stable now than it has been in a while! Wondering if it's a good idea to branch between the vagrant and other servers inside the one `setup_virtualenv` YAML file or if I should create a new YAML file that is only run depending on whether it's running locally or on the remote server.

Another thing to note is that everything runs as expected on remote servers in which we have login access to the server's `root` user. That might mean some preliminary server set up on the user's end 

To-Do's include:

![bees](https://cloud.githubusercontent.com/assets/5480842/14514666/9bedb1c0-01a7-11e6-8f7d-03edb6ab9adb.gif)

