### PR TITLE
BUG FIX: Copy `ansible.cfg` from Django project to parent directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Topic :: Software Development",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/yurt/yurt_core/setup.py
+++ b/yurt/yurt_core/setup.py
@@ -71,6 +71,10 @@ def move_vagrantfile_to_project_dir(*args):
     run('mv ./{0}/orchestration/Vagrantfile .'.format(project_name))
 
 
+def copy_ansible_configs_to_parent(*args):
+    _, project_name = args
+    run('cp {0}/ansible.cfg .'.format(project_name))
+
 @click.group()
 def setup():
     pass
@@ -178,6 +182,7 @@ def new_project(git_repo, vault):
         create_project,
         load_orchestration_and_requirements,
         move_vagrantfile_to_project_dir,
+        copy_ansible_configs_to_parent,
         add_all_files_to_git_repo
     ]
     args = create_settings(vault, git_repo)
@@ -211,6 +216,7 @@ def existing(git_repo):
     if not(repo_name == project_name):
         run("mv ./{0} ./{1}".format(repo_name, project_name))
     run("cp {0} ./".format(os.path.join(ORCHESTRATION_PROJECT_PATH, "Vagrantfile")))
+    run("cp {0} .".format(os.path.join(project_name, "ansible.cfg")))
     recursive_file_modify('./Vagrantfile', SETTINGS, is_dir=False)
     run("vagrant up")
 

--- a/yurt/yurt_core/tests/setup_test.py
+++ b/yurt/yurt_core/tests/setup_test.py
@@ -43,6 +43,7 @@ class SetupTestCase(BaseCase):
     ############################
 
     @mock.patch('yurt.yurt_core.setup.add_all_files_to_git_repo')
+    @mock.patch('yurt.yurt_core.setup.copy_ansible_configs_to_parent')
     @mock.patch('yurt.yurt_core.setup.move_vagrantfile_to_project_dir')
     @mock.patch('yurt.yurt_core.setup.load_orchestration_and_requirements')
     @mock.patch('yurt.yurt_core.setup.create_project')
@@ -78,6 +79,7 @@ class SetupTestCase(BaseCase):
             mock.call('git clone git@github.com:yeti/yeti-fan-page.git'),
             mock.call('mv ./yeti-fan-page ./yetifanpage'),
             mock.call('cp {0} ./'.format(os.path.join(ORCHESTRATION_PROJECT_PATH, 'Vagrantfile'))),
+            mock.call('cp yetifanpage/ansible.cfg .'),
             mock.call('vagrant up'),
         ]
         run_calls = mock_run.call_args_list
@@ -95,6 +97,7 @@ class SetupTestCase(BaseCase):
         expected_run_calls = [
             mock.call('git clone git@github.com:yeti/yeti_fan_page.git'),
             mock.call('cp {0} ./'.format(os.path.join(ORCHESTRATION_PROJECT_PATH, 'Vagrantfile'))),
+            mock.call('cp yeti_fan_page/ansible.cfg .'),
             mock.call('vagrant up'),
         ]
         run_calls = mock_run.call_args_list


### PR DESCRIPTION
- Add `invoke.run` command that copies the ansible.cfg file to the parent directory
- Fix tests
- Update supported Python versions on setup

@rmutter, handles issues with our `ansible.cfg` not being used on starting a new project or loading an existing one. We're currently using `ansible.cfg` to point to the correct roles folder to look at.