### PR TITLE
ENHANCE: Migrate node installation off Nodesource

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,6 @@ Setup
 .. code-block:: shell
 
     pip install yak-yurt
-    mkdir ~/roles
-    ansible-galaxy install nodesource.node -p ~/roles
     vagrant plugin install vagrant-vbguest
 
 Usage

--- a/yurt/orchestration/env_vars/vagrant.yml
+++ b/yurt/orchestration/env_vars/vagrant.yml
@@ -27,4 +27,6 @@ django_secret_key: "%(vagrant.secret_key)s"
 run_django_db_migrations: yes
 run_django_collectstatic: yes
 
-bashrc_path: "/home/vagrant/.bashrc"
+bashrc_user: "vagrant"
+home_path: "/home/{{ bashrc_user }}/"
+bashrc_path: "{{ home_path }}.bashrc"

--- a/yurt/orchestration/roles/app/tasks/setup_django_app.yml
+++ b/yurt/orchestration/roles/app/tasks/setup_django_app.yml
@@ -27,7 +27,7 @@
   tags: django.migrate
 
 - name: Install "less" node.js package globally.
-  npm: name=less global=yes
+  npm: name=less global=yes executable={{ home_path }}.nvm/versions/node/v4.4.7/bin/npm
 
 - name: Run Django collectstatic
   django_manage:

--- a/yurt/orchestration/roles/nvm/tasks/main.yml
+++ b/yurt/orchestration/roles/nvm/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Get bashrc
+  shell: cat {{ bashrc_path }}
+  register: bashrc_contents
+
+- name: Install NVM
+  shell: curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash
+  become_user: "{{ bashrc_user }}"
+  when: bashrc_contents.stdout.find('NVM_DIR=') == -1
+
+- name: Install Node version 4.4.7
+  shell: if [ -s {{ home_path }}.nvm/nvm.sh ]; then . {{ home_path }}.nvm/nvm.sh; fi && nvm install 4.4.7 executable=/bin/bash
+  become_user: "{{ bashrc_user }}"

--- a/yurt/orchestration/vagrant.yml
+++ b/yurt/orchestration/vagrant.yml
@@ -17,6 +17,6 @@
   roles:
     - base
     - memcached
-    - nodesource.node
+    - nvm
     - db
     - app

--- a/yurt/templates/env_vars.yml.template
+++ b/yurt/templates/env_vars.yml.template
@@ -47,4 +47,6 @@ django_secret_key: "%(secret_key)s"
 run_django_db_migrations: yes
 run_django_collectstatic: yes
 
-bashrc_path: "/root/.bashrc"
+bashrc_user: "root"
+home_path: "/{{ bashrc_user }}/"
+bashrc_path: "{{ home_path }}.bashrc"


### PR DESCRIPTION
- Create `nvm` role
- Make `nvm` role install nvm and through nvm, Node 4.4.7
- Change `setup_django_app` task to install LESS through nvm's Node

@rmutter, Handles #74! No more periodic issues where nodesource.node itself is completely broken.