### PR TITLE
BUG FIX: Use `nvm` role instead of `nodesource.node` role

### DIFF
--- a/yurt/orchestration/appservers.yml
+++ b/yurt/orchestration/appservers.yml
@@ -15,5 +15,5 @@
   roles:
     - base
     - memcached
-    - nodesource.node
+    - nvm
     - app

--- a/yurt/yurt_core/utils.py
+++ b/yurt/yurt_core/utils.py
@@ -20,7 +20,6 @@ def add_settings(vault, git_repo, test_mode=False):
     :param vault: boolean, do we have a vault that can be looked up
     :param git_repo: a git repo link
     :param test_mode: a flag that makes this method spoof private/public keygen
-    :return:
     """
     if not test_mode:
         public_key, private_key = generate_ssh_keypair()


### PR DESCRIPTION
@rmutter, just a quick fix to something I noticed just now. I was testing the new `nvm` role out on a personal project and forgot to change it to `nvm` for Yurt! 