### PR TITLE
BUG FIXES: Improve multi-project host experience and overall usability

### DIFF
--- a/yurt/orchestration/roles/app/tasks/setup_git_repo.yml
+++ b/yurt/orchestration/roles/app/tasks/setup_git_repo.yml
@@ -2,12 +2,12 @@
 
 - name: Create the SSH public key file
   copy: content="{{ git_ssh_pub_key }}"
-        dest=/root/.ssh/id_rsa.pub
+        dest="/root/.ssh/{{ project_name }}.pub"
         mode=0644
 
 - name: Create the SSH private key file
   copy: content="{{ git_ssh_priv_key }}"
-        dest=/root/.ssh/id_rsa
+        dest="/root/.ssh/{{ project_name }}"
         mode=0600
 
 - name: Setup the Git repo
@@ -15,6 +15,7 @@
        version="{{ git_branch }}"
        dest={{ project_path }}
        accept_hostkey=yes
+       key_file="/root/.ssh/{{ project_name }}"
   when: setup_git_repo is defined and setup_git_repo
   tags: git
 

--- a/yurt/orchestration/roles/db/tasks/main.yml
+++ b/yurt/orchestration/roles/db/tasks/main.yml
@@ -3,9 +3,9 @@
 - name: Install PostgreSQL
   apt: name={{ item }} update_cache={{ update_apt_cache }} state=installed
   with_items:
-    - postgresql=9.4*
-    - postgresql-contrib=9.4*
-    - python-psycopg2=2.5.*
+    - postgresql
+    - postgresql-contrib
+    - python-psycopg2
   tags: packages
 
 - name: Ensure the PostgreSQL service is running
@@ -20,8 +20,12 @@
                  template='template0'
                  state=present
 
+- name: Get absolute path to latest version of PostgreSQL main config file
+  shell: echo "/etc/postgresql/`ls /etc/postgresql | sort -r | head -1`/main/postgresql.conf"
+  register: conf_file_abs_path
+
 - name: Ensure postgres is listening for application servers
-  lineinfile: dest=/etc/postgresql/9.4/main/postgresql.conf
+  lineinfile: dest="{{ conf_file_abs_path }}"
               regexp="listen_addresses"
               line="listen_addresses = 'localhost,{{ db_host }}'"
               state=present

--- a/yurt/yurt_core/add.py
+++ b/yurt/yurt_core/add.py
@@ -16,7 +16,7 @@ ATTRIBUTE_TO_QUESTION_MAPPING = OrderedDict([
     ("abbrev_env", "How do you want this environment abbreviated (i.e. dev, stage, prod)?: "),
     ("app_host_dns", "What is the public DNS of this project's host (i.e. example.com)?: "),
     ("app_host_ip", "What is the IP of this project's host (i.e. 10.20.30.40)?: "),
-    ("db_host_ip", "What is this project's DB host (Hint: public IP of project if hosted locally)?: "),
+    ("db_host_ip", "What is this project's DB host (Hint: same IP as before if hosted locally)?: "),
     ("debug", "This Django server will use Debug mode (True/False): "),
     ("num_gunicorn_workers", "".join(("How many gunicorn workers do you want ",
                                       "(Hint: For the number of workers, a go",
@@ -25,13 +25,13 @@ ATTRIBUTE_TO_QUESTION_MAPPING = OrderedDict([
                                        "Setting this to 1 will restart the Gunicorn process each time ",
                                        "you make a request, basically reloading the code. Very han",
                                        "dy when developing. Set to 0 for unlimited requests.: "))),
-    ("ssl_enabled", "Is SSL enabled on this server (yes/no)?: "),
-    ("email_host", "Email host (i.e. 'smtp.google.com')?: "),
-    ("email_host_user", "Default email FROM user (i.e. 'dean@deanismyname.com')?: "),
-    ("email_host_password", "Email user's password: "),
-    ("email_port", "Email server port: "),
-    ("email_use_ssl", "Email server uses SSL (use `True` or `False`)?: "),
-    ("email_use_tls", "Email server uses TLS (use `True` or `False`)?: "),
+    ("ssl_enabled", "Is SSL enabled on this server,\nor in other words, is it using 'https://' (yes/no)?: "),
+    ("email_host", "Email host (default 'smtp.google.com')?: "),
+    ("email_host_user", "Default email FROM user (i.e. 'dean@deanismyname.com' or optional)?: "),
+    ("email_host_password", "Email user's password (optional)?: "),
+    ("email_port", "Email server port (default 687): "),
+    ("email_use_ssl", "Email server uses SSL (use `True` or `False`, default False)?: "),
+    ("email_use_tls", "Email server uses TLS (use `True` or `False`, default True)?: "),
     ("git_branch", "From which git branch will the server pull the project?: "),
     ("vault_used", "Are you utilizing a vault to store secrets for this server (yes/no)?: ")
 ])
@@ -79,9 +79,9 @@ def add():
 @click.option("--email_host", default=None, help="Email host DNS")
 @click.option("--email_host_user", default=None, help="Default FROM email user")
 @click.option("--email_host_password", default=None, help="FROM email user password")
-@click.option("--email_port", default=None, help="Email server port")
-@click.option("--email_use_ssl", default=None, help="Email user uses SSL (use `True` or `False`)?")
-@click.option("--email_use_tls", default=None, help="Email user uses TLS (use `True` or `False`)?")
+@click.option("--email_port", default='687', help="Email server port (default 687)")
+@click.option("--email_use_ssl", default='False', help="Email user uses SSL (use `True` or `False`, default False)?")
+@click.option("--email_use_tls", default='True', help="Email user uses TLS (use `True` or `False`, default True)?")
 @click.option("--vault_used", default=None, help="Uses 'vault_.json' file for vault lookup (use `yes` or `no`)")
 def remote_server(**kwargs):
     """

--- a/yurt/yurt_core/setup.py
+++ b/yurt/yurt_core/setup.py
@@ -167,8 +167,9 @@ def copy_pem_file(user, host, key_name):
 
 @setup.command()
 @click.option('--git_repo', default=None, help='Git Repo Link')
+@click.option('--skip_vagrant', is_flag=True, help='Skip `vagrant up` at the end of program')
 @click.option('--vault', is_flag=True, help="Uses vault for git keys")
-def new_project(git_repo, vault):
+def new_project(git_repo, skip_vagrant, vault):
     """
     Create new project
     """
@@ -192,7 +193,8 @@ def new_project(git_repo, vault):
     # TODO: Validate `args` before running them through THE GAUNTLET
     for method in ordered_methods:
         method(*args)
-    run('vagrant up')
+    if not skip_vagrant:
+        run('vagrant up')
 
 
 @setup.command()


### PR DESCRIPTION
* Designate the keyname to use as `{{project_name}}` instead of `id_rsa`
* Unpin postgresql version installations
* Add script that determines the latest version of postgresql
* Clariify vague questions in `remote_server` workflow
* Add optional `--no-vagrant` flag to making new projects

@rmutter, this PR handles [INT-126](https://yetillc.atlassian.net/browse/INT-126)(multi-project errors) and [INT-127](https://yetillc.atlassian.net/browse/INT-127)(unclear prompts). Please review!