### PR TITLE
ENHANCE: Enable Wheezy-specific installation

### DIFF
--- a/yurt/orchestration/roles/app/tasks/setup_virtualenv.yml
+++ b/yurt/orchestration/roles/app/tasks/setup_virtualenv.yml
@@ -27,9 +27,11 @@
 
 - name: Copy 'workon {environment}' statement to .bashrc
   lineinfile: dest={{ bashrc_path }} line="workon {{ application_name }}"
+  when: not multiple_yurt_project_server
 
 - name: Copy 'cd /path/to/application' statement to .bashrc
   lineinfile: dest={{ bashrc_path }} line="cd {{ project_path }}"
+  when: not multiple_yurt_project_server
 
 - name: Set permission to virtualenv path
   file: path={{ virtualenv_path }}

--- a/yurt/orchestration/roles/db/tasks/main.yml
+++ b/yurt/orchestration/roles/db/tasks/main.yml
@@ -20,12 +20,12 @@
                  template='template0'
                  state=present
 
-- name: Get absolute path to latest version of PostgreSQL main config file
-  shell: echo "/etc/postgresql/`ls /etc/postgresql | sort -r | head -1`/main/postgresql.conf"
-  register: conf_file_abs_path
+- name: Get PostgreSQL Version for Configuration
+  shell: ls /etc/postgresql | sort -r | head -1
+  register: conf_file_version
 
 - name: Ensure postgres is listening for application servers
-  lineinfile: dest="{{ conf_file_abs_path.stdout }}"
+  lineinfile: dest="/etc/postgresql/{{ conf_file_version.stdout }}/main/postgresql.conf"
               regexp="listen_addresses"
               line="listen_addresses = 'localhost,{{ db_host }}'"
               state=present
@@ -46,14 +46,26 @@
                    role_attr_flags=NOSUPERUSER,NOCREATEDB
                    state=present
 
-- name: Ensure application servers can access the db server
-  template: src=pg_hba_config.j2
-            dest=/etc/postgresql/9.4/main/pg_hba.conf
-            backup=yes
-  register: pga_hba_config
+- name: Create Client Authentication file if it does not exist yet
+  become_user: postgres
+  copy: src=roles/db/templates/pg_hba_config.j2
+        dest=/etc/postgresql/{{ conf_file_version.stdout }}/main/pg_hba.conf
+        backup=yes
+        force=no
+  register: pga_hba_created
   tags: pga_hba_config
+
+- name: Ensure application servers can access the db server
+  lineinfile: dest="/etc/postgresql/{{ conf_file_version.stdout }}/main/pg_hba.conf"
+              insertafter="host    all             all             127.0.0.1/32            md5"
+              line="host    {{ application_name }}    {{ application_name }}    {{ item }}/32    md5"
+              state=present
+  register: pga_hba_config
+  with_items: "{{ private_application_hosts }}"
+  tags: pga_hba_config
+
 
 - name: If we changed the pga_hba.conf file, restart postgresql
   service: name=postgresql state=restarted enabled=yes
-  when: pga_hba_config.changed or postgresql_config.changed
+  when: pga_hba_created.changed or pga_hba_config.changed or postgresql_config.changed
   tags: pga_hba_config

--- a/yurt/orchestration/roles/db/templates/pg_hba_config.j2
+++ b/yurt/orchestration/roles/db/templates/pg_hba_config.j2
@@ -91,9 +91,6 @@ local   all             all                                     peer
 
 # IPv4 local connections:
 host    all             all             127.0.0.1/32            md5
-{% for app_host in private_application_hosts|default([]) %}
-host    {{ application_name }}    {{ application_name }}    {{ app_host }}/32    md5
-{% endfor %}
 
 # IPv6 local connections:
 host    all             all             ::1/128                 md5

--- a/yurt/templates/env_vars.yml.template
+++ b/yurt/templates/env_vars.yml.template
@@ -50,3 +50,5 @@ run_django_collectstatic: yes
 bashrc_user: "root"
 home_path: "/{{ bashrc_user }}/"
 bashrc_path: "{{ home_path }}.bashrc"
+
+multiple_yurt_project_server: %(multiple_yurt_project_server)s

--- a/yurt/yurt_core/tests/add_test.py
+++ b/yurt/yurt_core/tests/add_test.py
@@ -62,6 +62,9 @@ class AddTestCase(BaseCase):
         self.assertEqual(mock_raw_input_wrapper.called, True)
         expected_run_calls = [
             'cp -rf {} ./templates.tmp'.format(TEMPLATES_PATH),
+            'rm -rf ./templates.tmp/yurtrc.template',
+            'rm -rf ./templates.tmp/temp_role',
+            'rm -rf ./templates.tmp/test_directory',
             "".join(('mv ./templates.tmp/env_settings.py.template ',
                      './themonstermash/config/settings/theyDidTheMash.py')),
             "".join(('mv ./templates.tmp/inventory.template ',

--- a/yurt/yurt_core/utils.py
+++ b/yurt/yurt_core/utils.py
@@ -83,9 +83,12 @@ def _perform_substitution(filepath, dictionary, pattern, all_vars_pattern):
             target_dictionary = dictionary.get(env_key).copy()
         else:
             target_dictionary = dictionary.copy()
-        file_text = re.sub(var_pattern, target_dictionary.get(variable), file_text)
-    with open(filepath, 'w') as change_file:
-        change_file.write(file_text)
+        try:
+            file_text = re.sub(var_pattern, target_dictionary.get(variable), file_text)
+        except TypeError:
+            print('Variable %({})s not sourced. Unfilled variable left in file {}.'.format(variable, filepath))
+        with open(filepath, 'w') as change_file:
+            change_file.write(file_text)
 
 
 def recursive_file_modify(path, dictionary, pattern=r"%\(({0})\)s", is_dir=True):


### PR DESCRIPTION
* Add `not multiple_yurt_project_server` flag to virtualenv tasks
* Change version-get call for postgres to output just the version
* Output the client authentication file and modify as necessary
* Remove templating markup in pb_hba_config.j2
* Add `multiple_yurt_project_server` var in server-specific cfg files
* Re-enable prompts for some `remote_server` options
* Exclude certain files in remote_server file creation
* Make bad variable fill-ins give warning

@rmutter, This allows us to use Yurt on Debian Wheezy again (it was mostly all). This also resolves some leftover issues with having multiple projects on the same server.