### PR TITLE
BUG FIX (#101): Changed admin url include to work with Django >=1.10

### DIFF
--- a/yurt/django_project/config/urls.py
+++ b/yurt/django_project/config/urls.py
@@ -18,5 +18,5 @@ from django.contrib import admin
 
 urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/yurt/requirements.txt
+++ b/yurt/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django==1.11.8
 django_compressor
 djangorestframework
 django-grappelli


### PR DESCRIPTION
Changed admin url include to be compatible with Django versions >=1.10, fixing #101.

Also changed Django version to latest LTS release (1.11.8) in requirements.txt to prevent future breaking changes.