### PR TITLE
[YV-13][YV-14][YV-15][YV-16] Add `yurt env`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 yak_yurt.egg-info/
 build/
+/__test
 .tox/
 .idea/
 .eggs/

--- a/yurt/django_project/plugins/lookup_plugins/vault.py
+++ b/yurt/django_project/plugins/lookup_plugins/vault.py
@@ -22,7 +22,6 @@ class LookupModule(LookupBase):
             raise Exception('Vagrantfile not found! If running `yurt vault`, run `yurt vault --dest=.`')
         return LookupModule.find_vagrantfile_dir(os.path.dirname(path))
 
-
     @classmethod
     def get_vault_from_path(cls, path):
         with open(path, 'r') as vault_file:

--- a/yurt/yurt_core/cli.py
+++ b/yurt/yurt_core/cli.py
@@ -2,8 +2,15 @@ import click
 from yurt.yurt_core.add import add
 from yurt.yurt_core.deploy import deploy_cli
 from yurt.yurt_core.setup import setup
+from yurt.yurt_core.env import env_vars
 
-main = click.CommandCollection(sources=[add, deploy_cli, setup])
+
+main = click.CommandCollection(sources=[
+    add,
+    deploy_cli,
+    setup,
+    env_vars
+])
 
 
 if __name__ == '__main__':

--- a/yurt/yurt_core/env.py
+++ b/yurt/yurt_core/env.py
@@ -1,0 +1,114 @@
+# coding=utf-8
+
+import click
+import os
+import re
+import yaml
+from cookiecutter.main import cookiecutter
+from shutil import copy2, make_archive
+from yurt.yurt_core.utils import get_iter, find_file_in_ancestor
+from zipfile import ZipFile
+
+
+# Helpers
+
+def in_yurt_directory():
+    return os.path.exists('./docker-compose.yml') and \
+           os.path.exists('./django_app') and \
+           os.path.exists('./envs')
+
+
+def add():
+    # Create env var file in envs
+    os.chdir('./envs')
+    result_path = cookiecutter('gh:yeti/yurt_template-envvars')
+    environment = re.search(r'envs/(.+)\.env\.d$', result_path).group(1)
+
+    # Copy docker-compose.remote.yml
+    os.chdir('..')
+    target_file = './docker-compose.{}.yml'.format(environment)
+    copy2(
+        './docker-compose.remote.yml',
+        './docker-compose.{}.yml'.format(environment)
+    )
+
+    # Edit copy with new env vars
+    with open(target_file, 'r+') as target_file_obj:
+        compose_contents = yaml.load(target_file_obj.read())
+        target_file_obj.seek(0)
+        target_file_obj.truncate()
+        env_file = './envs/{}.env'.format(environment)
+
+        all_services = compose_contents.get('services', {})
+        for key, _ in get_iter(all_services):
+            all_services[key]['env_file'] = [env_file]
+        compose_contents['services'] = all_services
+        yaml.dump(compose_contents, target_file_obj, default_flow_style=False)
+
+
+def import_func(src):
+    click.echo('==> Extracting {} into ./envs'.format(src))
+    with ZipFile(src) as zip_stream:
+        zip_stream.extractall('./envs')
+    click.echo('==> Success!')
+
+
+def export(filename):
+    click.echo('==> Exporting .envs/ into ./{}.zip'.format(filename))
+    make_archive(filename, 'zip', './envs')
+    click.echo('==> Success!')
+    click.echo('==> Upload this zip archive to a vault. To import:')
+    click.echo('👉  yurt env import <path-to-archive>')
+
+
+class EnvCommand:
+
+    __commands__ = {}
+
+    def __init__(self, subcommands):
+        for command_name, subcommand in subcommands:
+            self.__commands__[command_name] = subcommand
+
+    def invoke(self, command, *args):
+        callable_command = self.__commands__.get(command)
+        if callable_command is not None and callable(callable_command):
+            return callable_command(*args)
+        click.echo('yurt env {}: Command doesn\'t exist. Run yurt env --help'.format(command))
+
+
+# Actual Commands
+
+@click.group()
+def env_vars():
+    pass
+
+
+@env_vars.command()
+@click.argument('subcommand')
+@click.argument('args', nargs=-1)
+def env(subcommand, args):
+    """
+    Manage Environment Variable Files in your project
+
+    Subcommands:
+
+    👉 add - Add a new *.env file to ./envs and a new docker-compose.*.yml file
+
+    👉 import [SRC] - Import *.env files from {SRC}.zip to ./envs
+
+    👉 export [FILENAME] - Export *.env files from ./envs to {FILENAME}.zip
+    """
+    if not in_yurt_directory():
+        docker_compose_path = find_file_in_ancestor(
+            'docker-compose.yml',
+            stack_limit=3,
+            error_message='Could not find `docker-compose.yml` in this path. Are you in a project directory?'
+        )
+        os.chdir(docker_compose_path)
+    all_commands = [
+        ('add', add),
+        ('import', import_func),
+        ('export', export)
+    ]
+    env_commands = EnvCommand(all_commands)
+    env_commands.invoke(subcommand, *args)

--- a/yurt/yurt_core/setup.py
+++ b/yurt/yurt_core/setup.py
@@ -1,10 +1,9 @@
 # coding=utf-8
 import os
-import stat
 import click
 from builtins import input
 from invoke import run
-from yurt.yurt_core.utils import recursive_file_modify, generate_ssh_keypair, get_project_name_from_repo, add_settings
+from yurt.yurt_core.utils import recursive_file_modify, get_project_name_from_repo, add_settings
 from yurt.yurt_core.paths import DJANGO_PROJECT_PATH, ORCHESTRATION_PROJECT_PATH, YURT_PATH, TEMPLATES_PATH
 from cookiecutter.main import cookiecutter
 
@@ -142,14 +141,10 @@ def new():
     """
     template_location = 'gh:yeti/yurt_template-django'
     print('==> Creating a new project with Yurt Django 2.0 Template')
-    cookiecutter(template_location)
-    print('==> Project created: {}'.format(
-        os.path.join(
-            os.getcwd(),
-            '<project_name>'
-        )
-    ))
-    print('==> cd to the above path and run `docker-compose up`︎')
+    result = cookiecutter(template_location)
+    print('==> Project created: {}'.format(result))
+    print('==> To run dev project:')
+    print('👉  cd {} && docker-compose up'.format(result))
 
 
 @setup.command()

--- a/yurt/yurt_core/tests/add_test.py
+++ b/yurt/yurt_core/tests/add_test.py
@@ -134,5 +134,6 @@ class AddTestCase(BaseCase):
                      '/orchestration/roles user1.test_role'))
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/yurt/yurt_core/tests/base.py
+++ b/yurt/yurt_core/tests/base.py
@@ -1,4 +1,6 @@
 import unittest
+import os
+import shutil
 from click.testing import CliRunner
 
 
@@ -8,3 +10,22 @@ class BaseCase(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
+
+
+class FileSystemCase(BaseCase):
+    TEST_PATH = '__test'
+
+    def setUp(self):
+        self.root_path = os.getcwd()
+        super(FileSystemCase, self).setUp()
+        os.mkdir(os.path.join(self.root_path, self.TEST_PATH))
+        cookiecutter_home = os.path.expanduser('~/.cookiecutters')
+        if os.path.exists(cookiecutter_home):
+            shutil.rmtree(cookiecutter_home)
+
+    def tearDown(self):
+        os.chdir(self.root_path)
+        try:
+            shutil.rmtree(os.path.join(self.root_path, self.TEST_PATH))
+        except FileNotFoundError:
+            pass

--- a/yurt/yurt_core/tests/env_test.py
+++ b/yurt/yurt_core/tests/env_test.py
@@ -1,0 +1,74 @@
+import shutil
+
+from cookiecutter.main import cookiecutter
+
+from yurt.yurt_core.env import env_vars
+from yurt.yurt_core.tests.base import FileSystemCase
+import os
+
+from yurt.yurt_core.tests.utils import enter_test_directory
+
+
+class EnvTestCase(FileSystemCase):
+
+    @enter_test_directory
+    def test_env_add(self):
+        result = cookiecutter('gh:yeti/yurt_template-django', no_input=True)
+
+        os.chdir(result)
+
+        num_docker_compose_files = len([
+            item for item in os.listdir('.') if 'docker-compose' in item
+        ])
+
+        num_env_files = len([
+            item for item in os.listdir('./envs') if '.env' in item
+        ])
+
+        self.assertEqual(num_docker_compose_files, 2)
+        self.assertEqual(num_env_files, 2)
+        result = self.runner.invoke(env_vars, ['env', 'add'], input='test')
+        self.assertEqual(result.exit_code, 0)
+
+        # Check that docker-compose length increased
+        num_docker_compose_files = len([
+            item for item in os.listdir('.') if 'docker-compose' in item
+        ])
+        num_env_files = len([
+            item for item in os.listdir('./envs') if '.env' in item
+        ])
+
+        self.assertEqual(num_docker_compose_files, 3)
+        self.assertEqual(num_env_files, 3)
+
+    @enter_test_directory
+    def test_env_export_import(self):
+        path = cookiecutter('gh:yeti/yurt_template-django', no_input=True)
+
+        os.chdir(path)
+        self.runner.invoke(env_vars, ['env', 'add'], input='test')
+        self.runner.invoke(env_vars, ['env', 'add'], input='yes\ntest1')
+        self.runner.invoke(env_vars, ['env', 'add'], input='yes\ntest2')
+
+        self.assertTrue('test.env' in os.listdir('./envs'))
+        self.assertTrue('test1.env' in os.listdir('./envs'))
+        self.assertTrue('test2.env' in os.listdir('./envs'))
+
+        # Test export
+        result = self.runner.invoke(env_vars, ['env', 'export', 'test-zippy'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue('Success' in result.output)
+        self.assertTrue('test-zippy.zip' in os.listdir('.'))
+
+        # Test import
+        shutil.rmtree('./envs')
+        os.mkdir('./envs')
+
+        self.assertFalse('test.env' in os.listdir('./envs'))
+        self.assertFalse('test1.env' in os.listdir('./envs'))
+        self.assertFalse('test2.env' in os.listdir('./envs'))
+        result2 = self.runner.invoke(env_vars, ['env', 'import', './test-zippy.zip'])
+        self.assertEqual(result2.exit_code, 0)
+        self.assertTrue('test.env' in os.listdir('./envs'))
+        self.assertTrue('test1.env' in os.listdir('./envs'))
+        self.assertTrue('test2.env' in os.listdir('./envs'))

--- a/yurt/yurt_core/tests/setup_test.py
+++ b/yurt/yurt_core/tests/setup_test.py
@@ -1,6 +1,8 @@
 import os
-from yurt.yurt_core.tests.base import BaseCase
-from yurt.yurt_core.tests.utils import assemble_call_args_list, testmode_create_settings, fake_abspath
+
+from yurt.yurt_core.tests.base import FileSystemCase
+from yurt.yurt_core.tests.utils import assemble_call_args_list, fake_abspath, \
+    enter_test_directory
 from yurt.yurt_core.setup import enable_git_repo, create_project, load_orchestration_and_requirements, \
     move_vagrantfile_to_project_dir, add_all_files_to_git_repo
 from yurt.yurt_core.cli import main
@@ -18,7 +20,7 @@ except ImportError:
     OPEN_METHOD = '__builtin__.open'
 
 
-class SetupTestCase(BaseCase):
+class SetupTestCase(FileSystemCase):
 
     NEW_PROJECT_ARGS = [
         {
@@ -41,6 +43,19 @@ class SetupTestCase(BaseCase):
     ############################
     # Top-level Click commands #
     ############################
+
+    @enter_test_directory
+    def test_new(self):
+        cli_call = assemble_call_args_list("new", {})
+        result = self.runner.invoke(main, cli_call, input='test\n8080')
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue('test' in os.listdir('.'))
+        os.chdir('test')
+        self.assertTrue('docker-compose.yml' in os.listdir('.'))
+        self.assertTrue('django_app' in os.listdir('.'))
+        self.assertTrue('envs' in os.listdir('.'))
+        os.chdir('django_app')
+        self.assertTrue('test' in os.listdir('.'))
 
     @mock.patch('yurt.yurt_core.setup.recursive_file_modify')
     @mock.patch('yurt.yurt_core.setup.run')

--- a/yurt/yurt_core/tests/utils.py
+++ b/yurt/yurt_core/tests/utils.py
@@ -46,3 +46,11 @@ def fake_abspath(path):
     else:
         path = current_path_components
     return "/" + os.path.join('fake', 'abspath', *path)
+
+
+def enter_test_directory(func):
+    def wrapper(self, *args, **kwargs):
+        os.chdir(os.path.join(self.root_path, self.TEST_PATH))
+        func(self, *args, **kwargs)
+        os.chdir(self.root_path)
+    return wrapper


### PR DESCRIPTION
## Changes
* Add `yurt env` command
* Add tests for `yurt new` and `yurt env add`
* Add `yurt env import` and `yurt env export` commands (with tests)

## Visuals

### `yurt env --help`
![image](https://user-images.githubusercontent.com/5480842/42533981-4a2783a2-8440-11e8-8328-de4eebdb8883.png)

### `yurt env add`
![image](https://user-images.githubusercontent.com/5480842/42533917-13d862ee-8440-11e8-9f08-8f08ee107dce.png)

### `yurt env export <filename>`
![image](https://user-images.githubusercontent.com/5480842/42533931-23ae369e-8440-11e8-8fd1-5a7170cd3047.png)

### `yurt env import <path>`
![image](https://user-images.githubusercontent.com/5480842/42533953-30cd860e-8440-11e8-8e54-bff3800f44fb.png)

## Notes
Running `yurt env add` also adds a `docker-compose.<env>.yml` file that _can_ be checked into the project. This is fine. If a user tries to deploy without having the appropriate `.env` file in their `./envs` folder, we can put in place a descriptive error telling them they need to import an updated copy of the env vars.
