### PR TITLE
feat: added rootDir to compilerOptions in tsconfig.json

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -11,6 +11,7 @@
     "lib": ["esnext"],
     "module": "commonjs",
     "outDir": "dist",
+    "rootDir": "../backend",
     "paths": {
       "~/*": ["src/*"]
     },


### PR DESCRIPTION
Fix the `resolve-tspaths` call in the backend's `build` command by specifying `rootDir` in the backend's `tsconfig.json`.
