### PR TITLE
fix: update relative path for backend schema gen

### DIFF
--- a/packages/backend/src/schema.ts
+++ b/packages/backend/src/schema.ts
@@ -2,22 +2,21 @@ import { makeSchema } from 'nexus';
 import { NODE_ENV } from '~/config';
 import * as types from '~/schemaTypes';
 import path from 'path';
-import { fileURLToPath } from 'url';
 
-const directoryPath = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = process.cwd();
 
 export const schema = makeSchema({
   types,
   outputs: {
-    schema: path.join(directoryPath, '/../schema.graphql'),
+    schema: path.join(rootDir, '/schema.graphql'),
     typegen: path.join(
-      directoryPath,
-      './shared/types/gen/nexus-typegen/index.d.ts',
+      rootDir,
+      '/src/shared/types/gen/nexus-typegen/index.d.ts',
     ),
   },
   ...(NODE_ENV === 'development' && {
     contextType: {
-      module: path.join(directoryPath, 'context.ts'),
+      module: path.join(rootDir, '/src/context.ts'),
       export: 'Context',
     },
   }),

--- a/packages/backend/src/schema.ts
+++ b/packages/backend/src/schema.ts
@@ -3,20 +3,20 @@ import { NODE_ENV } from '~/config';
 import * as types from '~/schemaTypes';
 import path from 'path';
 
-const rootDir = process.cwd();
+const packageRootDir = process.cwd();
 
 export const schema = makeSchema({
   types,
   outputs: {
-    schema: path.join(rootDir, '/schema.graphql'),
+    schema: path.join(packageRootDir, '/schema.graphql'),
     typegen: path.join(
-      rootDir,
+      packageRootDir,
       '/src/shared/types/gen/nexus-typegen/index.d.ts',
     ),
   },
   ...(NODE_ENV === 'development' && {
     contextType: {
-      module: path.join(rootDir, '/src/context.ts'),
+      module: path.join(packageRootDir, '/src/context.ts'),
       export: 'Context',
     },
   }),


### PR DESCRIPTION
# Yurt

## Changes
Fixes path resolution when running jest tests -- the previous approach would use the root of the monorepo as the current directory when running `jest`, resulting in generated files in unintended directories.