### PR TITLE
feat: add useBrowserStorage hook to both frontend templates

### DIFF
--- a/packages/react-apollo/src/shared/constants.ts
+++ b/packages/react-apollo/src/shared/constants.ts
@@ -1,1 +1,5 @@
 export const IS_DEV = import.meta.env.DEV;
+
+export enum LocalStorageKeys {
+  StoredId = 'storedId',
+}

--- a/packages/react-apollo/src/shared/hooks/storage/useBrowserStorage.tsx
+++ b/packages/react-apollo/src/shared/hooks/storage/useBrowserStorage.tsx
@@ -1,5 +1,5 @@
 import { useSyncExternalStore, useRef } from 'react';
-import { IS_DEV } from '../constants';
+import { IS_DEV } from '../../constants';
 
 type StorageType = 'localStorage' | 'sessionStorage';
 
@@ -7,7 +7,7 @@ const getStorageObject = (type: StorageType) => {
   return type === 'localStorage' ? window.localStorage : window.sessionStorage;
 };
 
-const useBrowserStorage = <T,>(
+export const useBrowserStorage = <T,>(
   key: string,
   initialValue: T,
   storageType: StorageType,
@@ -66,15 +66,3 @@ const useBrowserStorage = <T,>(
 
   return [value, setValue] as const;
 };
-
-// Convenience hooks to instantiate either a localStorage or sessionStorage
-// hook
-export const useLocalStorage = <T,>(key: string, initialValue: T) => {
-  return useBrowserStorage(key, initialValue, 'localStorage');
-};
-
-export const useSessionStorage = <T,>(key: string, initialValue: T) => {
-  return useBrowserStorage(key, initialValue, 'sessionStorage');
-};
-
-export default useBrowserStorage;

--- a/packages/react-apollo/src/shared/hooks/storage/useBrowserStorage.tsx
+++ b/packages/react-apollo/src/shared/hooks/storage/useBrowserStorage.tsx
@@ -45,10 +45,10 @@ export const useBrowserStorage = <T,>(
 
   const setValue = (value: T | ((prev: T) => T)) => {
     try {
-      const currentValue = getSnapshot();
+      const currentValue = cachedValue.current;
       const newValue = value instanceof Function ? value(currentValue) : value;
 
-      window.sessionStorage.setItem(key, JSON.stringify(newValue));
+      storage.setItem(key, JSON.stringify(newValue));
       cachedValue.current = newValue;
 
       window.dispatchEvent(

--- a/packages/react-apollo/src/shared/hooks/storage/useLocalStorage.tsx
+++ b/packages/react-apollo/src/shared/hooks/storage/useLocalStorage.tsx
@@ -1,0 +1,15 @@
+import { LocalStorageKeys } from '~/shared/constants';
+import { useBrowserStorage } from './useBrowserStorage';
+
+export const useLocalStorage = <T,>(key: string, initialValue: T) => {
+  return useBrowserStorage(key, initialValue, 'localStorage');
+};
+
+export const useStoredId = () => {
+  const [storedId, setStoredId] = useLocalStorage(
+    LocalStorageKeys.StoredId,
+    null,
+  );
+
+  return { storedId, setStoredId } as const;
+};

--- a/packages/react-apollo/src/shared/hooks/storage/useLocalStorage.tsx
+++ b/packages/react-apollo/src/shared/hooks/storage/useLocalStorage.tsx
@@ -1,7 +1,7 @@
 import { LocalStorageKeys } from '~/shared/constants';
 import { useBrowserStorage } from './useBrowserStorage';
 
-export const useLocalStorage = <T,>(key: string, initialValue: T) => {
+const useLocalStorage = <T,>(key: string, initialValue: T) => {
   return useBrowserStorage(key, initialValue, 'localStorage');
 };
 

--- a/packages/react-apollo/src/shared/hooks/useBrowserStorage.tsx
+++ b/packages/react-apollo/src/shared/hooks/useBrowserStorage.tsx
@@ -10,7 +10,7 @@ const getStorageObject = (type: StorageType) => {
 const useBrowserStorage = <T,>(
   key: string,
   initialValue: T,
-  storageType: StorageType = 'localStorage',
+  storageType: StorageType,
 ) => {
   const storage = getStorageObject(storageType);
   const cachedValue = useRef<T>(initialValue);

--- a/packages/react-apollo/src/shared/hooks/useBrowserStorage.tsx
+++ b/packages/react-apollo/src/shared/hooks/useBrowserStorage.tsx
@@ -1,0 +1,80 @@
+import { useSyncExternalStore, useRef } from 'react';
+import { IS_DEV } from '../constants';
+
+type StorageType = 'localStorage' | 'sessionStorage';
+
+const getStorageObject = (type: StorageType) => {
+  return type === 'localStorage' ? window.localStorage : window.sessionStorage;
+};
+
+const useBrowserStorage = <T,>(
+  key: string,
+  initialValue: T,
+  storageType: StorageType = 'localStorage',
+) => {
+  const storage = getStorageObject(storageType);
+  const cachedValue = useRef<T>(initialValue);
+
+  const getSnapshot = () => {
+    try {
+      const item = storage.getItem(key);
+      const value = item ? JSON.parse(item) : initialValue;
+
+      if (JSON.stringify(cachedValue.current) !== JSON.stringify(value)) {
+        cachedValue.current = value;
+      }
+
+      return cachedValue.current as T;
+    } catch (error) {
+      IS_DEV && console.error(error);
+
+      return initialValue;
+    }
+  };
+
+  const subscribe = (listener: () => void) => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === key) {
+        listener();
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  };
+
+  const setValue = (value: T | ((prev: T) => T)) => {
+    try {
+      const currentValue = getSnapshot();
+      const newValue = value instanceof Function ? value(currentValue) : value;
+
+      window.sessionStorage.setItem(key, JSON.stringify(newValue));
+      cachedValue.current = newValue;
+
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key,
+          newValue: JSON.stringify(newValue),
+        }),
+      );
+    } catch (error) {
+      IS_DEV && console.error(error);
+    }
+  };
+
+  const value = useSyncExternalStore(subscribe, getSnapshot);
+
+  return [value, setValue] as const;
+};
+
+// Convenience hooks to instantiate either a localStorage or sessionStorage
+// hook
+export const useLocalStorage = <T,>(key: string, initialValue: T) => {
+  return useBrowserStorage(key, initialValue, 'localStorage');
+};
+
+export const useSessionStorage = <T,>(key: string, initialValue: T) => {
+  return useBrowserStorage(key, initialValue, 'sessionStorage');
+};
+
+export default useBrowserStorage;

--- a/packages/react/src/shared/constants.ts
+++ b/packages/react/src/shared/constants.ts
@@ -1,1 +1,5 @@
 export const IS_DEV = import.meta.env.DEV;
+
+export enum LocalStorageKeys {
+  StoredId = 'storedId',
+}

--- a/packages/react/src/shared/hooks/storage/useBrowserStorage.tsx
+++ b/packages/react/src/shared/hooks/storage/useBrowserStorage.tsx
@@ -1,5 +1,5 @@
 import { useSyncExternalStore, useRef } from 'react';
-import { IS_DEV } from '../constants';
+import { IS_DEV } from '../../constants';
 
 type StorageType = 'localStorage' | 'sessionStorage';
 
@@ -7,7 +7,7 @@ const getStorageObject = (type: StorageType) => {
   return type === 'localStorage' ? window.localStorage : window.sessionStorage;
 };
 
-const useBrowserStorage = <T,>(
+export const useBrowserStorage = <T,>(
   key: string,
   initialValue: T,
   storageType: StorageType,
@@ -66,15 +66,3 @@ const useBrowserStorage = <T,>(
 
   return [value, setValue] as const;
 };
-
-// Convenience hooks to instantiate either a localStorage or sessionStorage
-// hook
-export const useLocalStorage = <T,>(key: string, initialValue: T) => {
-  return useBrowserStorage(key, initialValue, 'localStorage');
-};
-
-export const useSessionStorage = <T,>(key: string, initialValue: T) => {
-  return useBrowserStorage(key, initialValue, 'sessionStorage');
-};
-
-export default useBrowserStorage;

--- a/packages/react/src/shared/hooks/storage/useBrowserStorage.tsx
+++ b/packages/react/src/shared/hooks/storage/useBrowserStorage.tsx
@@ -45,10 +45,10 @@ export const useBrowserStorage = <T,>(
 
   const setValue = (value: T | ((prev: T) => T)) => {
     try {
-      const currentValue = getSnapshot();
+      const currentValue = cachedValue.current;
       const newValue = value instanceof Function ? value(currentValue) : value;
 
-      window.sessionStorage.setItem(key, JSON.stringify(newValue));
+      storage.setItem(key, JSON.stringify(newValue));
       cachedValue.current = newValue;
 
       window.dispatchEvent(

--- a/packages/react/src/shared/hooks/storage/useLocalStorage.tsx
+++ b/packages/react/src/shared/hooks/storage/useLocalStorage.tsx
@@ -1,0 +1,15 @@
+import { LocalStorageKeys } from '~/shared/constants';
+import { useBrowserStorage } from './useBrowserStorage';
+
+export const useLocalStorage = <T,>(key: string, initialValue: T) => {
+  return useBrowserStorage(key, initialValue, 'localStorage');
+};
+
+export const useStoredId = () => {
+  const [storedId, setStoredId] = useLocalStorage(
+    LocalStorageKeys.StoredId,
+    null,
+  );
+
+  return { storedId, setStoredId } as const;
+};

--- a/packages/react/src/shared/hooks/storage/useLocalStorage.tsx
+++ b/packages/react/src/shared/hooks/storage/useLocalStorage.tsx
@@ -1,7 +1,7 @@
 import { LocalStorageKeys } from '~/shared/constants';
 import { useBrowserStorage } from './useBrowserStorage';
 
-export const useLocalStorage = <T,>(key: string, initialValue: T) => {
+const useLocalStorage = <T,>(key: string, initialValue: T) => {
   return useBrowserStorage(key, initialValue, 'localStorage');
 };
 

--- a/packages/react/src/shared/hooks/useBrowserStorage.tsx
+++ b/packages/react/src/shared/hooks/useBrowserStorage.tsx
@@ -10,7 +10,7 @@ const getStorageObject = (type: StorageType) => {
 const useBrowserStorage = <T,>(
   key: string,
   initialValue: T,
-  storageType: StorageType = 'localStorage',
+  storageType: StorageType,
 ) => {
   const storage = getStorageObject(storageType);
   const cachedValue = useRef<T>(initialValue);

--- a/packages/react/src/shared/hooks/useBrowserStorage.tsx
+++ b/packages/react/src/shared/hooks/useBrowserStorage.tsx
@@ -1,0 +1,80 @@
+import { useSyncExternalStore, useRef } from 'react';
+import { IS_DEV } from '../constants';
+
+type StorageType = 'localStorage' | 'sessionStorage';
+
+const getStorageObject = (type: StorageType) => {
+  return type === 'localStorage' ? window.localStorage : window.sessionStorage;
+};
+
+const useBrowserStorage = <T,>(
+  key: string,
+  initialValue: T,
+  storageType: StorageType = 'localStorage',
+) => {
+  const storage = getStorageObject(storageType);
+  const cachedValue = useRef<T>(initialValue);
+
+  const getSnapshot = () => {
+    try {
+      const item = storage.getItem(key);
+      const value = item ? JSON.parse(item) : initialValue;
+
+      if (JSON.stringify(cachedValue.current) !== JSON.stringify(value)) {
+        cachedValue.current = value;
+      }
+
+      return cachedValue.current as T;
+    } catch (error) {
+      IS_DEV && console.error(error);
+
+      return initialValue;
+    }
+  };
+
+  const subscribe = (listener: () => void) => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === key) {
+        listener();
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  };
+
+  const setValue = (value: T | ((prev: T) => T)) => {
+    try {
+      const currentValue = getSnapshot();
+      const newValue = value instanceof Function ? value(currentValue) : value;
+
+      window.sessionStorage.setItem(key, JSON.stringify(newValue));
+      cachedValue.current = newValue;
+
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key,
+          newValue: JSON.stringify(newValue),
+        }),
+      );
+    } catch (error) {
+      IS_DEV && console.error(error);
+    }
+  };
+
+  const value = useSyncExternalStore(subscribe, getSnapshot);
+
+  return [value, setValue] as const;
+};
+
+// Convenience hooks to instantiate either a localStorage or sessionStorage
+// hook
+export const useLocalStorage = <T,>(key: string, initialValue: T) => {
+  return useBrowserStorage(key, initialValue, 'localStorage');
+};
+
+export const useSessionStorage = <T,>(key: string, initialValue: T) => {
+  return useBrowserStorage(key, initialValue, 'sessionStorage');
+};
+
+export default useBrowserStorage;


### PR DESCRIPTION
# Yurt

## Changes
- Add `useBrowserStorage` hook to both frontend temlates.
- Add example `useLocalStorage` hook and related constant to demonstrate how `useBrowserStorage` can be used.

## Notes (optional)
Adding this to `yurt` as a follow-up from our Dev Roundup conversation this week. Hopefully, others will find this helpful on future projects!