### PR TITLE
feat: initial agent-os standards and setup

### DIFF
--- a/.agent-os/standards/best-practices.md
+++ b/.agent-os/standards/best-practices.md
@@ -1,0 +1,148 @@
+# Development Best Practices
+
+## Context
+
+Global development guidelines for Agent OS projects.
+
+<conditional-block context-check="core-principles">
+IF this Core Principles section already read in current context:
+  SKIP: Re-reading this section
+  NOTE: "Using Core Principles already in context"
+ELSE:
+  READ: The following principles
+
+## Core Principles
+
+### Keep It Simple
+
+- Implement code in the fewest lines possible
+- Avoid over-engineering solutions
+- Choose straightforward approaches over clever ones
+
+### Optimize for Readability
+
+- Prioritize code clarity over micro-optimizations
+- Write self-documenting code with clear variable names
+- Add comments for "why" not "what"
+
+### DRY (Don't Repeat Yourself)
+
+- Extract repeated business logic to private methods
+- Extract repeated UI markup to reusable components
+- Create utility functions for common operations
+
+### File Structure
+
+- Keep files focused on a single responsibility
+- Group related functionality together
+- Use consistent naming conventions
+
+#### Frontend File Structure
+
+Root Level:
+
+- Standard React/Vite configuration files (package.json, tsconfig.json, vite.config.ts)
+- Entry points: src/index.tsx, src/App.tsx
+- MSW setup: public/mockServiceWorker.js for API mocking
+
+src/
+├── apollo/ # Apollo Client configuration and setup
+├── modules/ # Feature-based modules (auth, home, profile)
+├── shared/ # Reusable cross-module code
+│ ├── components/ # Common UI components (Layout, ErrorPage, NotFound)
+│ ├── hooks/ # Custom hooks organized by category (storage/)
+│ ├── styles/ # Theme system with component-specific styling
+│ ├── types/ # TypeScript definitions
+│ ├── queries/ # Shared GraphQL queries
+│ ├── mutations/ # Shared GraphQL mutations
+│ ├── constants.ts # App-wide constants
+│ └── config.ts # Configuration settings
+├── services/ # API and external service integrations
+├── stores/ # State management
+├── tests/ # Test configuration and setup
+│ └── mocks/ # MSW API mocking setup
+├── assets/ # Static assets
+└── static/ # Static resources (icons)
+
+#### Backend File Structure
+
+Root Level:
+
+- GraphQL server configuration (schema.ts, server.ts, serverSetup.ts)
+- Database setup: Prisma schema and migrations in prisma/
+- Entry point: src/server.ts
+- Dev tooling: nodemon.json, .eslintrc.js
+
+GraphQL API Architecture:
+src/
+├── schemaModules/ # Feature-based GraphQL schema modules
+│ └── user/ # Domain-specific modules (user, etc.)
+│ ├── index.ts # Module exports
+│ ├── objectTypes._.ts # GraphQL object type definitions
+│ ├── queries._.ts # GraphQL query resolvers
+│ ├── mutations.\*.ts # GraphQL mutation resolvers
+│ └── tests/ # Module-specific tests
+├── apolloPlugins/ # Apollo Server plugins (sentry, logger)
+├── services/ # Service classes (external APIs, internal domains, etc.)
+│ └── Http/ # HTTP service with tests
+├── shared/ # Cross-module utilities
+│ ├── types/ # Shared TypeScript definitions
+│ ├── utils.ts # Utility functions
+│ └── constants.ts # App-wide constants
+├── tests/ # Global test setup and helpers
+├── context.ts # GraphQL context setup
+├── permissions.ts # GraphQL Shield permissions
+├── prismaClient.ts # Prisma database client
+├── config.ts # Environment configuration
+└── loggers.ts # Logging setup
+
+prisma/
+├── migrations/ # Database migration files
+├── schema.prisma # Database schema definition
+└── seed.ts # Database seeding script
+
+Key Backend Patterns:
+
+- GraphQL-first: Nexus-based type-safe GraphQL schema with code generation
+- Domain modules: Schema organized by business domain (user/, etc.)
+- Type safety: Nexus + Prisma for end-to-end type safety
+- Prisma ORM-driven: Prisma ORM with migrations and seeding
+- Plugin architecture: Modular Apollo Server plugins (Sentry, logging)
+- Testing: Jest with Docker Compose for isolated database testing
+- Security: GraphQL Shield for permissions, Helmet for HTTP server security headers
+
+Tech Stack:
+
+- GraphQL: Apollo Server 4 + Nexus code-first approach
+- Database: Prisma ORM with PostgreSQL
+- Runtime: Node.js with Express
+- Testing: Jest with Supertest and Docker-based test databases
+- Monitoring: Sentry integration and Pino logging
+
+  </conditional-block>
+
+<conditional-block context-check="dependencies" task-condition="choosing-external-library">
+IF current task involves choosing an external library:
+  IF Dependencies section already read in current context:
+    SKIP: Re-reading this section
+    NOTE: "Using Dependencies guidelines already in context"
+  ELSE:
+    READ: The following guidelines
+ELSE:
+  SKIP: Dependencies section not relevant to current task
+
+## Dependencies
+
+### Choose Libraries Wisely
+
+When adding third-party dependencies:
+
+- Select the most popular and actively maintained option
+- Check the library's GitHub repository for:
+  - Recent commits (within last 6 months)
+  - Active issue resolution
+  - Number of stars/downloads
+  - Clear documentation
+- Make sure the library provides TypeScript type definitions either within the package or within a `@types/*` package on `npm`
+
+  </conditional-block>

--- a/.agent-os/standards/best-practices.md
+++ b/.agent-os/standards/best-practices.md
@@ -18,11 +18,14 @@ ELSE:
 - Implement code in the fewest lines possible
 - Avoid over-engineering solutions
 - Choose straightforward approaches over clever ones
+- Avoid redundant layers of abstraction
 
 ### Optimize for Readability
 
 - Prioritize code clarity over micro-optimizations
-- Write self-documenting code with clear variable names
+- Write self-documenting code with clear, descriptive variable names. Avoid
+  single-letter abbreviations (e.g., x, y, i) unless they are conventional in
+  context (such as loop counters or mathematical formulas).
 - Add comments for "why" not "what"
 
 ### DRY (Don't Repeat Yourself)

--- a/.agent-os/standards/code-style.md
+++ b/.agent-os/standards/code-style.md
@@ -42,6 +42,7 @@ ELSE:
 - Never remove existing comments unless removing the associated code
 - Update comments when modifying code to maintain accuracy
 - Keep comments concise and relevant
+- Never use comments as section markers in React trees (TSX or JSX)
   </conditional-block>
 
 <conditional-block task-condition="html-css-tailwind" context-check="html-css-style">

--- a/.agent-os/standards/code-style.md
+++ b/.agent-os/standards/code-style.md
@@ -1,0 +1,82 @@
+# Code Style Guide
+
+## Context
+
+Global code style rules for Agent OS projects.
+
+<conditional-block context-check="general-formatting">
+IF this General Formatting section already read in current context:
+  SKIP: Re-reading this section
+  NOTE: "Using General Formatting rules already in context"
+ELSE:
+  READ: The following formatting rules
+
+## General Formatting
+
+### Indentation
+
+- Use tabs for indendation
+- Maintain consistent indentation throughout files
+- Align nested structures for readability
+
+### Naming Conventions
+
+- **Methods and Variables**: Use camelCase (e.g., `userProfile`, `calculateTotal`)
+- **Database models**: Use PascalCase in prisma schema definition, mapped to
+  snake_case (e.g., `user_profile`, `calculate_total`) in underlying database
+  names
+- **Classes**: Use PascalCase (e.g., `UserProfile`, `PaymentProcessor`)
+- **Constants**: Use UPPER_SNAKE_CASE (e.g., `MAX_RETRY_COUNT`)
+
+### String Formatting
+
+- Use single quotes for strings: `'Hello World'`
+- Use double quotes only when interpolation is needed
+- Use template literals for multi-line strings or complex interpolation
+
+### Code Comments
+
+- Add brief comments above non-obvious business logic
+- Document complex algorithms or calculations
+- Explain the "why" behind implementation choices
+- Never remove existing comments unless removing the associated code
+- Update comments when modifying code to maintain accuracy
+- Keep comments concise and relevant
+  </conditional-block>
+
+<conditional-block task-condition="html-css-tailwind" context-check="html-css-style">
+IF current task involves writing or updating HTML or CSS:
+  IF css-style.md already in context:
+    SKIP: Re-reading this file
+    NOTE: "Using CSS style guide already in context"
+  ELSE:
+    <context_fetcher_strategy>
+      IF current agent is Claude Code AND context-fetcher agent exists:
+        USE: @agent:context-fetcher
+        REQUEST: "Get CSS rules from code-style/css-style.md"
+        PROCESS: Returned style rules
+      ELSE:
+        READ the following style guides (only if not already in context):
+        - @.agent-os/standards/code-style/css-style.md (if not in context)
+    </context_fetcher_strategy>
+ELSE:
+  SKIP: CSS style guide not relevant to current task
+</conditional-block>
+
+<conditional-block task-condition="javascript" context-check="javascript-style">
+IF current task involves writing or updating JavaScript:
+  IF javascript-style.md already in context:
+    SKIP: Re-reading this file
+    NOTE: "Using JavaScript style guide already in context"
+  ELSE:
+    <context_fetcher_strategy>
+      IF current agent is Claude Code AND context-fetcher agent exists:
+        USE: @agent:context-fetcher
+        REQUEST: "Get JavaScript style rules from code-style/javascript-style.md"
+        PROCESS: Returned style rules
+      ELSE:
+        READ: @.agent-os/standards/code-style/javascript-style.md
+    </context_fetcher_strategy>
+ELSE:
+  SKIP: JavaScript style guide not relevant to current task
+</conditional-block>

--- a/.agent-os/standards/code-style/css-style.md
+++ b/.agent-os/standards/code-style/css-style.md
@@ -1,0 +1,5 @@
+# CSS Style Guide
+
+We always use the latest version of MUI for all CSS.
+
+Use project prettier settings for formatting style-related code.

--- a/.agent-os/standards/code-style/javascript-style.md
+++ b/.agent-os/standards/code-style/javascript-style.md
@@ -16,3 +16,5 @@ npx lint-staged
 **Never** use the `any` type to bypass the TypeScript compiler. If you are
 unable to determine the correct type for a value, stop and prompt the developer
 for help.
+
+**Never** nest ternary functions.

--- a/.agent-os/standards/code-style/javascript-style.md
+++ b/.agent-os/standards/code-style/javascript-style.md
@@ -1,0 +1,18 @@
+# Javascript Style Guide
+
+Use Prettier config file, TypeScript config, and eslint rules as guidelines for
+specific JavaScript and TypeScript conventions.
+
+All code should be auto-formatted using a husky pre-commit hook, which should
+already be installed in the repository:
+
+```bash
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged
+```
+
+**Never** use the `any` type to bypass the TypeScript compiler. If you are
+unable to determine the correct type for a value, stop and prompt the developer
+for help.

--- a/.agent-os/standards/tech-stack.md
+++ b/.agent-os/standards/tech-stack.md
@@ -1,0 +1,33 @@
+# Tech Stack
+
+## Context
+
+Global tech stack defaults for Agent OS projects, overridable in project-specific `.agent-os/product/tech-stack.md`.
+
+- App Framework: React, GraphQL (apollo client + server), Node, Express
+- Language: TypeScript
+- Primary Database: PostgreSQL 17+
+- ORM: Prisma
+- JavaScript Framework: React latest stable
+- Build Tool: Vite
+- Dependency Mangement: pnpm
+- Import Strategy: Node.js modules
+- Package Manager: pnpm
+- Node Version: 24 LTS
+- CSS Framework: MUI + @emotion/styled + @emotion/react
+- UI Components: MUI v6
+- Font Provider: Google Fonts
+- Font Loading: Self-hosted for performance when possible
+- Icons: MUI icons or custom from design
+- Application Hosting: Render.com
+- Hosting Region: Primary region based on user base
+- Database Hosting: Render Managed PostgreSQL
+- Database Backups: Daily automated
+- Asset Storage: Amazon S3 or Cloudinary for images
+- CDN: Cloudinary
+- Asset Access: Private with signed URLs
+- CI/CD Platform: GitHub Actions
+- CI/CD Trigger: Push to main/develop branches
+- Tests: Run before deployment
+- Production Environment: main branch
+- Staging Environment: develop branch


### PR DESCRIPTION
# Yurt

## Changes
This PR takes a first pass at defining standards for the [agent-os](https://github.com/buildermethods/agent-os) system of "spec-driven" development with Cursor and/or Claude Code (though really I think this approach could be used with most anything).

The system installs a base configuration in the `~/.agent-os` directory. In this directory you tweak specific instructions as necessary, and define your **standards.** These standards are meant to capture how you want software built, your best practices, etc. The goal is a consistent baseline context in these spec-driven flows. You then run a shell script that copies this system into your specific repo, where further tweaks can be made.

Here's [a video describing how it works](https://www.youtube.com/watch?v=4PlVnrliN3Q).

Feedback, ideas, and requested changes appreciated!