### PR TITLE
feat: use timestamptz for all backend DateTime columns

### DIFF
--- a/packages/backend/prisma/migrations/20260121203832_initial_user_table/migration.sql
+++ b/packages/backend/prisma/migrations/20260121203832_initial_user_table/migration.sql
@@ -6,6 +6,8 @@ CREATE TABLE "user" (
     "id" SERIAL NOT NULL,
     "email" CITEXT NOT NULL,
     "first_name" TEXT,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
 
     CONSTRAINT "user_pkey" PRIMARY KEY ("id")
 );

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -13,9 +13,11 @@ datasource db {
 }
 
 model User {
-  id        Int     @id @default(autoincrement())
-  email     String  @unique @db.Citext
-  firstName String? @map("first_name")
+  id        Int      @id @default(autoincrement())
+  email     String   @unique @db.Citext
+  firstName String?  @map("first_name")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   @@map("user")
 }

--- a/packages/backend/src/tests/timestamptz.test.ts
+++ b/packages/backend/src/tests/timestamptz.test.ts
@@ -1,0 +1,106 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Enforces the convention that every Prisma `DateTime` column is stored as
+ * `timestamptz` (via `@db.Timestamptz`) rather than Prisma's default `timestamp
+ * without time zone`.
+ */
+
+const SCHEMA_DIR = path.resolve(import.meta.dirname, "../../prisma");
+const MIGRATIONS_SEGMENT = `${path.sep}migrations${path.sep}`;
+const BLOCK_OPEN = /^(?:model|type)\s+\w+\s*\{/;
+const TYPE_MODIFIER = /(?:\?|\[])$/;
+const TIMESTAMPTZ = /@db\.Timestamptz/;
+const WHITESPACE = /\s+/;
+
+interface DateTimeColumn {
+  field: string;
+  file: string;
+  isTimestamptz: boolean;
+  line: number;
+}
+
+function findPrismaSchemaFiles(dir: string): string[] {
+  return readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".prisma"))
+    .map((entry) => path.join(entry.parentPath, entry.name))
+    .filter((file) => !file.includes(MIGRATIONS_SEGMENT));
+}
+
+function stripComment(line: string): string {
+  const commentStart = line.indexOf("//");
+  return commentStart === -1 ? line : line.slice(0, commentStart);
+}
+
+function collectDateTimeColumns(): DateTimeColumn[] {
+  const columns: DateTimeColumn[] = [];
+
+  for (const file of findPrismaSchemaFiles(SCHEMA_DIR)) {
+    const lines = readFileSync(file, "utf8").split("\n");
+    let insideModel = false;
+
+    for (const [index, rawLine] of lines.entries()) {
+      const line = stripComment(rawLine).trim();
+      if (line === "") {
+        continue;
+      }
+
+      // Only `model`/`type` bodies hold typed fields; skip datasource,
+      // generator, and enum blocks so their contents can never match.
+      if (BLOCK_OPEN.test(line)) {
+        insideModel = true;
+        continue;
+      }
+
+      if (line === "}") {
+        insideModel = false;
+        continue;
+      }
+
+      if (!insideModel) {
+        continue;
+      }
+
+      const tokens = line.split(WHITESPACE);
+      if (tokens.length < 2) {
+        continue;
+      }
+
+      // A field's type is its second token; strip any `?`/`[]` modifier.
+      const [field, rawType] = tokens;
+      if (rawType.replace(TYPE_MODIFIER, "") !== "DateTime") {
+        continue;
+      }
+
+      columns.push({
+        field,
+        file: path.relative(SCHEMA_DIR, file),
+        isTimestamptz: TIMESTAMPTZ.test(line),
+        line: index + 1,
+      });
+    }
+  }
+
+  return columns;
+}
+
+describe("Prisma DateTime columns", () => {
+  it("reads the prisma schema (sanity guard)", () => {
+    // Guards against a broken path.
+    expect(findPrismaSchemaFiles(SCHEMA_DIR).length).toBeGreaterThan(0);
+  });
+
+  it("uses @db.Timestamptz for every DateTime column", () => {
+    const offenders = collectDateTimeColumns()
+      .filter((column) => !column.isTimestamptz)
+      .map((column) => `${column.file}:${column.line} ${column.field}`);
+
+    expect(
+      offenders,
+      `DateTime columns must be timestamptz. Add \`@db.Timestamptz(3)\` to:\n${offenders.join(
+        "\n"
+      )}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Add `createdAt`/`updatedAt` to the `User` model as `@db.Timestamptz(3)`, folded into the single initial migration (matching JS Date and Prisma's native millisecond precision). 

Add a test enforcing `@db.Timestamptz` on every Prisma `DateTime` column so the convention holds as the schema grows.